### PR TITLE
Specify pr number

### DIFF
--- a/probot-app-report-benchmarks/index.js
+++ b/probot-app-report-benchmarks/index.js
@@ -87,7 +87,8 @@ module.exports = app => {
     );
     if (comment == undefined) {
       return context.github.issues.createComment(
-        context.issue({
+        context.repo({
+          number: pull_request.number,
           body: commentBody,
         })
       );


### PR DESCRIPTION
Context.issue does not contain the pr number unless the trigger was caused by a pr.