### PR TITLE
Remove release flag from wrangler deploy script

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -8,7 +8,7 @@ cd benchmarks-image-service
 # See: https://github.com/cloudflare/wrangler/pull/225
 wrangler config dummy_value dummy_value
 
-wrangler publish --release
+wrangler publish
 
 cd ../probot-app-report-benchmarks
 


### PR DESCRIPTION
the --release flag requires the use of a zone_id and route in the wrangler. 
we could either supply those values, or remove the flag; removing the flag is easier.