### PR TITLE
Display comment only when the CLI has changed

### DIFF
--- a/probot-app-report-benchmarks/index.js
+++ b/probot-app-report-benchmarks/index.js
@@ -176,19 +176,15 @@ module.exports = app => {
         })
       ),
     ]);
-    if (
+    return (
       headTarballHashes.data.total_count > 0 &&
-      baseTarballHashes.data.total_count > 0
-    ) {
-      return (
-        JSON.parse(headTarballHashes.data.check_runs[0].output.text).packages[
-          "fusion-cli"
-        ].shasum !==
+      baseTarballHashes.data.total_count > 0 &&
+      JSON.parse(headTarballHashes.data.check_runs[0].output.text).packages[
+        "fusion-cli"
+      ].shasum !==
         JSON.parse(baseTarballHashes.data.check_runs[0].output.text).packages[
           "fusion-cli"
         ].shasum
-      );
-    }
-    return false; //assume no changes by default
+    );
   }
 };


### PR DESCRIPTION
If the fusion-cli hasn't changed, then there is no reason to post summary of benchmarks comment. This should help to clean up some clutter form some PRs